### PR TITLE
Nissix plugin scope-packages on react-native-sortable-list

### DIFF
--- a/examples/Basic/App.js
+++ b/examples/Basic/App.js
@@ -15,7 +15,7 @@ import {
   Dimensions,
   Platform,
 } from 'react-native';
-import SortableList from 'react-native-sortable-list';
+import SortableList from '@wix/react-native-sortable-list';
 
 const window = Dimensions.get('window');
 

--- a/examples/Basic/package.json
+++ b/examples/Basic/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
     "react": "16.0.0",
     "react-native": "0.50.3",
-   	"react-native-sortable-list": "0.0.17"
+    "@wix/react-native-sortable-list": "0.0.17"
   }
 }

--- a/examples/Horizontal/App.js
+++ b/examples/Horizontal/App.js
@@ -15,7 +15,7 @@ import {
   Dimensions,
   Platform,
 } from 'react-native';
-import SortableList from 'react-native-sortable-list';
+import SortableList from '@wix/react-native-sortable-list';
 
 const window = Dimensions.get('window');
 

--- a/examples/Horizontal/package.json
+++ b/examples/Horizontal/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "Horizontal",
+  "name": "Horizontal",
   "version": "0.0.1",
   "private": true,
   "scripts": {
@@ -9,6 +9,6 @@
   "dependencies": {
     "react": "16.0.0",
     "react-native": "0.50.3",
-    "react-native-sortable-list": "0.0.17"
+    "@wix/react-native-sortable-list": "0.0.17"
   }
 }


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.411s



Output Log:
Migrating package "react-native-sortable-list" in .


## Migration from non scope to @wix/scoped packages
> /tmp/17bd7dcfad333059d4bef4b81c981520

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
examples/Basic/package.json
examples/Horizontal/package.json
```

#### replace import/require in js/ts files
```
examples/Basic/App.js
examples/Horizontal/App.js
```

