### PR TITLE
Nissix plugin scope-packages on Basic

### DIFF
--- a/examples/Basic/App.js
+++ b/examples/Basic/App.js
@@ -15,7 +15,7 @@ import {
   Dimensions,
   Platform,
 } from 'react-native';
-import SortableList from 'react-native-sortable-list';
+import SortableList from '@wix/react-native-sortable-list';
 
 const window = Dimensions.get('window');
 

--- a/examples/Basic/package.json
+++ b/examples/Basic/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
     "react": "16.0.0",
     "react-native": "0.50.3",
-   	"react-native-sortable-list": "0.0.17"
+    "@wix/react-native-sortable-list": "0.0.17"
   }
 }


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.25s
error Couldn't find any versions for "@wix/react-native-sortable-list" that matches "0.0.17"
(node:26857) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 1: yarn
    at makeError (/app/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/app/node_modules/execa/index.js:114:26)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:26857) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:26857) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.



Output Log:
Migrating package "Basic" in examples/Basic


## Migration from non scope to @wix/scoped packages
> /tmp/adb3c6e0a9e542266e7aae9b652834a9/examples/Basic

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
App.js
```
yarn install v1.22.5
[1/4] Resolving packages...
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

